### PR TITLE
fix "test" method not cd "current_path"

### DIFF
--- a/lib/capistrano3/tasks/unicorn.rake
+++ b/lib/capistrano3/tasks/unicorn.rake
@@ -15,7 +15,7 @@ namespace :unicorn do
   task :start do
     on roles(fetch(:unicorn_roles)) do
       within current_path do
-        if test("[ -e #{fetch(:unicorn_pid)} ] && kill -0 #{pid}")
+        if test(*("[ -e #{fetch(:unicorn_pid)} ] && kill -0 #{pid}").split(' '))
           info "unicorn is running..."
         else
           with rails_env: fetch(:rails_env), bundle_gemfile: fetch(:unicorn_bundle_gemfile) do


### PR DESCRIPTION
The "test" method won't cd current_path, if pid is set as a relative path, the "test" method will allways return false. 

Ref: https://github.com/capistrano/sshkit/issues/23