### PR TITLE
Remove killing of old unicorn after restart

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,10 +24,6 @@ You can override the defaults by `set :unicorn_example, value` in the `config/de
 
     Assumes that your Unicorn configuration will be located in `config/unicorn/RAILS_ENV.rb`
 
-- `:unicorn_restart_sleep_time`
-
-    When performing zero-downtime deployment via the `unicorn:restart` task, send the USR2 signal, sleep for this many seconds (defaults to 3), then send the QUIT signal
-
 - `:unicorn_roles`
 
     Roles to run unicorn commands on. Defaults to :app

--- a/lib/capistrano3/tasks/unicorn.rake
+++ b/lib/capistrano3/tasks/unicorn.rake
@@ -2,7 +2,6 @@ namespace :load do
   task :defaults do
     set :unicorn_pid, -> { File.join(current_path, "tmp", "pids", "unicorn.pid") }
     set :unicorn_config_path, -> { File.join(current_path, "config", "unicorn", "#{fetch(:rails_env)}.rb") }
-    set :unicorn_restart_sleep_time, 3
     set :unicorn_roles, -> { :app }
     set :unicorn_options, -> { "" }
     set :unicorn_rack_env, -> { fetch(:rails_env) == "development" ? "development" : "deployment" }
@@ -63,10 +62,6 @@ namespace :unicorn do
       within current_path do
         info "unicorn restarting..."
         execute :kill, "-s USR2", pid
-        execute :sleep, fetch(:unicorn_restart_sleep_time)
-        if test("[ -e #{fetch(:unicorn_pid)}.oldbin ]")
-          execute :kill, "-s QUIT", pid_oldbin
-        end
       end
     end
   end


### PR DESCRIPTION
It is somewhat conventional to have this in your unicorn config file in
before_fork block

``` ruby
  # Quit the old unicorn process
  old_pid = "#{server.config[:pid]}.oldbin"
  if File.exists?(old_pid) && server.pid != old_pid
    begin
      Process.kill("QUIT", File.read(old_pid).to_i)
    rescue Errno::ENOENT, Errno::ESRCH
      # someone else did our job for us
    end
  end
```

Moreover, there might be different variations with incremental phase out
of old master, etc.

So it's better to have full control of phase out strategy in your
unicorn config rather than putting this on capistrano task.
