### PR TITLE
make possible to use unicorn.rb config file

### DIFF
--- a/lib/capistrano3/tasks/unicorn.rake
+++ b/lib/capistrano3/tasks/unicorn.rake
@@ -1,7 +1,13 @@
 namespace :load do
   task :defaults do
     set :unicorn_pid, -> { File.join(current_path, "tmp", "pids", "unicorn.pid") }
-    set :unicorn_config_path, -> { File.join(current_path, "config", "unicorn", "#{fetch(:rails_env)}.rb") }
+    set :unicorn_config_path, -> do
+      if File.exist?(File.join(current_path, "config", "unicorn", "#{fetch(:rails_env)}.rb"))
+        File.join(current_path, "config", "unicorn", "#{fetch(:rails_env)}.rb")
+      else
+        File.join(current_path, "config", "unicorn.rb")
+      end
+    end
     set :unicorn_restart_sleep_time, 3
     set :unicorn_roles, -> { :app }
     set :unicorn_options, -> { "" }


### PR DESCRIPTION
Usually the unicorn config file is put in config/unicorn.rb, which is different to your convention.

So if config/unicorn/#{rails_env} file is not found, it will search whether 'config/unicorn.rb' exists
