### PR TITLE
Customize unicorn command

### DIFF
--- a/lib/capistrano3/tasks/unicorn.rake
+++ b/lib/capistrano3/tasks/unicorn.rake
@@ -1,6 +1,6 @@
 namespace :load do
   task :defaults do
-    set :unicorn_command, 'bundle exec unicorn'
+    set :unicorn_command, -> { [:bundle, :exec, :unicorn] }
     set :unicorn_pid, -> { current_path.join('tmp', 'pids', 'unicorn.pid') }
     set :unicorn_config_path, -> do
       unicorn_env_path = current_path.join('config', 'unicorn', "#{fetch(:rails_env)}.rb")
@@ -26,7 +26,7 @@ namespace :unicorn do
           info "unicorn is running..."
         else
           with rails_env: fetch(:rails_env) do
-            execute fetch(:unicorn_command), '-c', fetch(:unicorn_config_path), '-E', fetch(:unicorn_rack_env), '-D', fetch(:unicorn_options)
+            execute *fetch(:unicorn_command), '-c', fetch(:unicorn_config_path), '-E', fetch(:unicorn_rack_env), '-D', fetch(:unicorn_options)
           end
         end
       end


### PR DESCRIPTION
Lets you customize unicorn command to something other than `bundle exec
unicorn`, for example `bin/unicorn`.

Also includes minor updates such as using `current_path.join` instead of
`File.join`.
