### PR TITLE
Point Unicorn to current/Gemfile instead of release dir.

### DIFF
--- a/lib/capistrano3/tasks/unicorn.rake
+++ b/lib/capistrano3/tasks/unicorn.rake
@@ -17,8 +17,10 @@ namespace :unicorn do
         if test("[ -e #{fetch(:unicorn_pid)} ] && kill -0 #{pid}")
           info "unicorn is running..."
         else
-          with rails_env: fetch(:rails_env) do
-            execute :bundle, "exec unicorn", "-c", fetch(:unicorn_config_path), "-E", fetch(:unicorn_rack_env), "-D", fetch(:unicorn_options)
+          with rails_env: fetch(:rails_env),
+               bundle_gemfile: current_path.join("Gemfile") \
+          do
+            execute :bundle, "exec", "unicorn", "-c", fetch(:unicorn_config_path), "-E", fetch(:unicorn_rack_env), "-D", fetch(:unicorn_options)
           end
         end
       end


### PR DESCRIPTION
Without this env variable unicorn master process remembers path to Gemfile of specific release. This causes two problems when reloading unicorn using USR2 signal:
1. Gems are not refreshed if Gemfile has changed since the release when unicorn was started.
2. If the release from which unicorn was started is removed due to `keep_releases` option, unicorn will fail to reload (since that Gemfile is no longer available).

You need to `cap stage unicorn:stop && cap stage unicorn:start` for this fix to be applied.
