### PR TITLE
"kill -0" has no effect, use "kill -9" instead

### DIFF
--- a/lib/capistrano3/tasks/unicorn.rake
+++ b/lib/capistrano3/tasks/unicorn.rake
@@ -18,7 +18,7 @@ namespace :unicorn do
           info "unicorn is running..."
         else
           with rails_env: fetch(:rails_env) do
-            execute "if [[ ! -e #{File.join(current_path, 'tmp', 'pids')} ]]; then mkdir -p #{File.join(current_path, 'tmp', 'pids')}; fi"
+            # execute "if [[ ! -e #{File.join(current_path, 'tmp', 'pids')} ]]; then mkdir -p #{File.join(current_path, 'tmp', 'pids')}; fi"
             execute :bundle, "exec unicorn", "-c", fetch(:unicorn_config_path), "-E", fetch(:unicorn_rack_env), "-D", fetch(:unicorn_options)
           end
         end


### PR DESCRIPTION
cat app_path/current/tmp/pids/unicorn.pid
-> 8727
kill -0 `cat app_path/current/tmp/pids/unicorn.pid`
ps aux | grep "unicorn"
-> ... 8727 ... app_pathl/current/config/unicorn/production.rb -E deployment -D ... 
