### PR TITLE
Remove bundler dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,13 @@ This is a capistrano v3 plugin that integrates Unicorn tasks into capistrano dep
 
 ### Gotchas
 
-- The `unicorn:start` task invokes unicorn as `bundle exec unicorn`.
-
 - When running tasks not during a full deployment, you may need to run the `rvm:hook`:
 
     `cap production rvm:hook unicorn:start`
+
+- To use unicorn with bundler, you'll have to add the `capistrano-bundler` gem, and add the unicorn command to the bundle bins:
+    
+    `set :bundle_bins, fetch(:bundle_bins, []).push('unicorn')`
 
 ### Conventions
 

--- a/lib/capistrano3/tasks/unicorn.rake
+++ b/lib/capistrano3/tasks/unicorn.rake
@@ -18,7 +18,7 @@ namespace :unicorn do
           info "unicorn is running..."
         else
           with rails_env: fetch(:rails_env) do
-            execute :bundle, "exec unicorn", "-c", fetch(:unicorn_config_path), "-E", fetch(:unicorn_rack_env), "-D", fetch(:unicorn_options)
+            execute :unicorn, "-c", fetch(:unicorn_config_path), "-E", fetch(:unicorn_rack_env), "-D", fetch(:unicorn_options)
           end
         end
       end


### PR DESCRIPTION
This change makes using bundler optional

More on this here: https://github.com/capistrano/bundler#usage